### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusted_cypher"
-version = "0.7.1"
+version = "0.7.1-pb"
 authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
 description = "Send cypher queries to a neo4j database"
 repository = "https://github.com/livioribeiro/rusted-cypher"
@@ -17,14 +17,14 @@ nightly = ["serde_macros"]
 
 [build-dependencies]
 serde_codegen = { version = "0.6", optional = true }
-syntex = "0.17"
+syntex = "0.22"
 
 [dependencies]
-hyper = "0.6"
-url = "0.2"
+hyper = "0.7"
+url = "0.5"
 serde = "0.6"
 serde_json = "0.6"
 serde_macros = { version = "0.6", optional = true }
-semver = "0.1"
+semver = "0.2"
 time = "0.1"
 log = "0.3"


### PR DESCRIPTION
We're using Iron internally at product-bio for routing, at it depends on a newer version of Hyper (0.7) which, in turn, requires a newer version of the openssl library. Cargo requires that a native library can only be linked to a single Cargo package, so when integrating rusted-cypher, my project simply would not compile.

I also took the liberty of bumping some other outdated dependencies flagged by `cargo outdated`. Tests seem to be passing on my end despite the updates!