### PR TITLE
Fix serde dependency on syntex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusted_cypher"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
 description = "Send cypher queries to a neo4j database"
 repository = "https://github.com/livioribeiro/rusted-cypher"

--- a/build.rs
+++ b/build.rs
@@ -7,15 +7,12 @@ mod inner {
     use std::path::Path;
 
     pub fn main() {
-        let out_dir = env::var_os("OUT_DIR").unwrap();
+       let out_dir = env::var_os("OUT_DIR").unwrap();
 
        let src = Path::new("src/lib.rs.in");
        let dst = Path::new(&out_dir).join("lib.rs");
 
-       let mut registry = syntex::Registry::new();
-
-       serde_codegen::register(&mut registry);
-       registry.expand("", &src, &dst).unwrap();
+       serde_codegen::expand(&src, &dst).unwrap();
     }
 }
 


### PR DESCRIPTION
When trying to build rusted_cypher, I ran into a problem where syntex would fail with the error message:
```
   Compiling rusted_cypher v0.9.0 (file:///Users/lonkastenson/Development/rust/rusted-cypher)
build.rs:17:32: 17:45 error: mismatched types [E0308]
build.rs:17        serde_codegen::register(&mut registry);
                                           ^~~~~~~~~~~~~
build.rs:17:32: 17:45 help: run `rustc --explain E0308` to see a detailed explanation
build.rs:17:32: 17:45 note: expected type `&mut syntex::Registry`
build.rs:17:32: 17:45 note:    found type `&mut inner::syntex::Registry`
error: aborting due to previous error
```
An alternative method has been implemented by the serde developers which is detailed here. I implemented that in rusted-cypher.

https://users.rust-lang.org/t/here-is-how-to-avoid-being-broken-by-syntex-updates/6189?u=dtolnay

Please let me know any feedback that I can make this pr any better. Thank you.